### PR TITLE
Promote deployments crd to app/v1 version

### DIFF
--- a/travel_agency.yaml
+++ b/travel_agency.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: discounts-v1
 spec:
+  selector:
+    matchLabels:
+      app: discounts
+      version: v1
   replicas: 1
   template:
     metadata:
@@ -40,11 +44,15 @@ spec:
   selector:
     app: discounts
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flights-v1
 spec:
+  selector:
+    matchLabels:
+      app: flights
+      version: v1
   replicas: 1
   template:
     metadata:
@@ -83,11 +91,15 @@ spec:
   selector:
     app: flights
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hotels-v1
 spec:
+  selector:
+    matchLabels:
+      app: hotels
+      version: v1
   replicas: 1
   template:
     metadata:
@@ -126,11 +138,15 @@ spec:
   selector:
     app: hotels
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cars-v1
 spec:
+  selector:
+    matchLabels:
+      app: cars
+      version: v1
   replicas: 1
   template:
     metadata:
@@ -169,11 +185,15 @@ spec:
   selector:
     app: cars
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: insurances-v1
 spec:
+  selector:
+    matchLabels:
+      app: insurances
+      version: v1
   replicas: 1
   template:
     metadata:
@@ -212,12 +232,16 @@ spec:
   selector:
     app: insurances
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: travels-v1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: travels
+      version: v1
   template:
     metadata:
       annotations:

--- a/travel_agency_v2.yaml
+++ b/travel_agency_v2.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: discounts-v2
 spec:
+  selector:
+    matchLabels:
+      app: discounts
+      version: v2
   replicas: 1
   template:
     metadata:
@@ -30,11 +34,15 @@ spec:
             - name: CHAOS_MONKEY_SLEEP
               value: "50"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flights-v2
 spec:
+  selector:
+    matchLabels:
+      app: flights
+      version: v2
   replicas: 1
   template:
     metadata:
@@ -64,11 +72,15 @@ spec:
             - name: CHAOS_MONKEY_SLEEP
               value: "50"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hotels-v2
 spec:
+  selector:
+    matchLabels:
+      app: hotels
+      version: v2
   replicas: 1
   template:
     metadata:
@@ -98,11 +110,15 @@ spec:
             - name: CHAOS_MONKEY_SLEEP
               value: "50"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cars-v2
 spec:
+  selector:
+    matchLabels:
+      app: cars
+      version: v2
   replicas: 1
   template:
     metadata:
@@ -132,11 +148,15 @@ spec:
             - name: CHAOS_MONKEY_SLEEP
               value: "50"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: insurances-v2
 spec:
+  selector:
+    matchLabels:
+      app: insurances
+      version: v2
   replicas: 1
   template:
     metadata:
@@ -166,11 +186,15 @@ spec:
             - name: CHAOS_MONKEY_SLEEP
               value: "50"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: travels-v2
 spec:
+  selector:
+    matchLabels:
+      app: travels
+      version: v2
   replicas: 1
   template:
     metadata:

--- a/travel_portal.yaml
+++ b/travel_portal.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rome-portal-web
 spec:
+  selector:
+    matchLabels:
+      app: rome-portal
+      version: web
   replicas: 1
   template:
     metadata:
@@ -28,11 +32,15 @@ spec:
             - name: CITY_PORTAL
               value: "rome"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rome-portal-vip
 spec:
+  selector:
+    matchLabels:
+      app: rome-portal
+      version: vip
   replicas: 1
   template:
     metadata:
@@ -60,11 +68,15 @@ spec:
             - name: USER_TYPE
               value: "vip"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: paris-portal-web
 spec:
+  selector:
+    matchLabels:
+      app: paris-portal
+      version: web
   replicas: 1
   template:
     metadata:
@@ -90,11 +102,15 @@ spec:
             - name: CITY_PORTAL
               value: "paris"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: paris-portal-vip
 spec:
+  selector:
+    matchLabels:
+      app: paris-portal
+      version: vip
   replicas: 1
   template:
     metadata:
@@ -122,11 +138,15 @@ spec:
             - name: USER_TYPE
               value: "vip"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: london-portal-web
 spec:
+  selector:
+    matchLabels:
+      app: london-portal
+      version: web
   replicas: 1
   template:
     metadata:
@@ -152,11 +172,15 @@ spec:
             - name: CITY_PORTAL
               value: "london"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: london-portal-vip
 spec:
+  selector:
+    matchLabels:
+      app: london-portal
+      version: vip
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Keeping the deployments up to date. My kubernetes complains about the version of the deployments: 
`extensions/v1beta1` are no longer supported. They are moved to `apps/v1`.
Deployments also need to have the `selector` field with its labels added.

![Screenshot of Kiali Console (26)](https://user-images.githubusercontent.com/613814/78655876-dd4ead00-78c6-11ea-8bea-e074ef2182a0.png)
